### PR TITLE
Create conf/update file even without content.

### DIFF
--- a/manifests/repository.pp
+++ b/manifests/repository.pp
@@ -145,6 +145,7 @@ define reprepro::repository (
     owner   => $owner,
     group   => $group,
     mode    => '0640',
+    force   => true, 
     require => File["${basedir}/${name}/conf"],
   }
 


### PR DESCRIPTION
puppet (3.7.3)
jtopjian-reprepro (1.4.0)
puppetlabs-concat (1.1.2)

I tried simple configuration: 
```ruby
  $basedir = '/srv/reprepro'

  class { 'reprepro':
    basedir => $basedir,
  }

  reprepro::repository { 'ubuntu':
    ensure  => present,
    basedir => $basedir,
    options => ['basedir .'],
  }

  reprepro::distribution { 'precise':
    basedir       => $basedir,
    repository    => 'ubuntu',
    origin        => 'Foobar',
    label         => 'Foobar',
    suite         => 'precise',
    architectures => 'amd64',
    components    => 'main contrib non-free',
    description   => 'Package repository for local site maintenance',
    sign_with     => 'XXXX',
    not_automatic => 'No',
  } 
```
and got messages:
==> default: Notice: /Stage[main]/Main/Node[default]/Reprepro::Repository[ubuntu]/Concat[/srv/reprepro/ubuntu/conf/updates]/Exec[concat_/srv/reprepro/ubuntu/conf/updates]/returns: The fragments directory is empty, cowardly refusing to make empty config files
==> default: Error: /var/lib/puppet/concat/bin/concatfragments.sh -o "/var/lib/puppet/concat/_srv_reprepro_ubuntu_conf_updates/fragments.concat.out" -d "/var/lib/puppet/concat/_srv_reprepro_ubuntu_conf_updates" returned 1 instead of one of [0]