### PR TITLE
Fix repositories without any pull configuration

### DIFF
--- a/manifests/repository.pp
+++ b/manifests/repository.pp
@@ -153,6 +153,7 @@ define reprepro::repository (
     owner   => root,
     group   => root,
     mode    => '0644',
+    force   => true,
     require => File["${basedir}/${name}/conf"],
   }
 


### PR DESCRIPTION
This fixes the same problem for pulls that #37 fixed for updates. We
have to add the `force` flag to concat to avoid an error at catalog
application time when no pulls are defined for a repository.