### PR TITLE
add homedir parameter for distribuition

### DIFF
--- a/manifests/distribution.pp
+++ b/manifests/distribution.pp
@@ -55,6 +55,7 @@ define reprepro::distribution (
   $codename            = $name,
   $ensure              = present,
   $basedir             = $::reprepro::params::basedir,
+  $homedir             = $::reprepro::params::homedir,
   $fakecomponentprefix = undef,
   $udebcomponents      = $components,
   $deb_indices         = 'Packages Release .gz .bz2',
@@ -104,9 +105,9 @@ define reprepro::distribution (
   if $install_cron {
 
     if $snapshots {
-      $command = "${::reprepro::params::homedir}/bin/update-distribution.sh -r ${repository} -d ${suite} -c ${name} -s"
+      $command = "${homedir}/bin/update-distribution.sh -r ${repository} -d ${suite} -c ${name} -s"
     } else {
-      $command = "${::reprepro::params::homedir}/bin/update-distribution.sh -r ${repository} -d ${suite} -c ${name}"
+      $command = "${homedir}/bin/update-distribution.sh -r ${repository} -d ${suite} -c ${name}"
     }
 
     cron { "${name} cron":
@@ -114,7 +115,7 @@ define reprepro::distribution (
       user        => $::reprepro::params::user_name,
       environment => 'SHELL=/bin/bash',
       minute      => '*/5',
-      require     => File["${::reprepro::params::homedir}/bin/update-distribution.sh"],
+      require     => File["${homedir}/bin/update-distribution.sh"],
     }
   }
 }


### PR DESCRIPTION
If missing, distribiution fails upon dependencies if
homedir is set in init.pp