### PR TITLE
Accounts for non-humans should be system accounts.

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -23,6 +23,7 @@ class reprepro (
   group { 'reprepro':
     ensure => present,
     name   => $::reprepro::params::group_name,
+    system => true,
   }
 
   user { 'reprepro':
@@ -33,6 +34,7 @@ class reprepro (
     comment    => 'Reprepro user',
     gid        => 'reprepro',
     managehome => true,
+    system     => true,
     require    => Group['reprepro'],
   }
 

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -24,6 +24,7 @@ describe 'reprepro' do
         :comment    => 'Reprepro user',
         :gid        => 'reprepro',
         :managehome => true,
+        :system     => true,
       }).that_requires('Group[reprepro]')
     end
 
@@ -65,6 +66,7 @@ describe 'reprepro' do
         :comment    => 'Reprepro user',
         :gid        => 'reprepro',
         :managehome => true,
+        :system     => true,
       }).that_requires('Group[reprepro]')
     end
 


### PR DESCRIPTION
This ensures that they are created within the correct UID/GID range for system accounts, and not alongside normal users.