### PR TITLE
Use $CODENAME with includedeb.

### DIFF
--- a/templates/update-distribution.sh.erb
+++ b/templates/update-distribution.sh.erb
@@ -48,8 +48,8 @@ fi
 cd ${BASEDIR}/${REPOSITORY}/tmp/${CODENAME}
 ls *.deb 2>/dev/null
 if [ $? -eq 0 ]; then 
-  $REPREPRO -b ${BASEDIR}/${REPOSITORY} includedeb $DISTRIBUTION *.deb; 
-  rm -f *.deb; 
+  $REPREPRO -b ${BASEDIR}/${REPOSITORY} includedeb $CODENAME *.deb
+  if [ $? -eq 0 ]; then rm -f *.deb; fi
 
   if ${SNAPSHOTS}; then
     SNAPDIR="${BASEDIR}/${REPOSITORY}/dists/${DISTRIBUTION}/snapshots"


### PR DESCRIPTION
According to the manual page:

```includedeb codename .deb-filename```

It works fine with $DISTRIBUTION as long as you don't have two distributions with the same name. For example, stable/trusty and stable/precise.

Also only delete packages if includedeb succeeded. In case of errors further inspection may be required.