### PR TITLE
Fix to work with puppetlabs-concat 2.0.0+.

### DIFF
--- a/manifests/repository.pp
+++ b/manifests/repository.pp
@@ -141,12 +141,24 @@ define reprepro::repository (
     require => File["${basedir}/${name}/conf"],
   }
 
+  concat::fragment { "00-distributions-${name}":
+    ensure  => $ensure,
+    content => "# Puppet managed\n",
+    target  => "${basedir}/${name}/conf/distributions",
+  }
+
   concat { "${basedir}/${name}/conf/updates":
     owner   => $owner,
     group   => $group,
     mode    => '0640',
     force   => true, 
     require => File["${basedir}/${name}/conf"],
+  }
+
+  concat::fragment { "00-update-${name}":
+    ensure  => $ensure,
+    content => "# Puppet managed\n",
+    target  => "${basedir}/${name}/conf/updates",
   }
 
   concat {"${basedir}/${name}/conf/pulls":
@@ -157,4 +169,9 @@ define reprepro::repository (
     require => File["${basedir}/${name}/conf"],
   }
 
+  concat::fragment { "00-pulls-${name}":
+    ensure  => $ensure,
+    content => "# Puppet managed\n",
+    target  => "${basedir}/${name}/conf/pulls",
+  }
 }


### PR DESCRIPTION
The concat module changed behaviour in 2.0.0 such that concats without any fragments generate an error:

```The fragments directory is empty, cowardly refusing to make empty config files```

One fix would have been to enable the force option. But this wouldn't have been backwards compatible; older versions of the module would generate a deprecation warning (force was deprecated prior to 2.0.0 and then undeprecated in 2.0.0).

So this fix simply adds a gratuitious header to the files which fixes the problem on 2.0.0+ and doesn't cause an issue with older versions.

*Since writing this I note that puppetlabs-concat 2.0.0 has been pulled. I'm still submitting this so it's available if/when 2.0.0 is re-released. It'd also be safe to merge anyway.*