### PR TITLE
Added export after include of new packages

### DIFF
--- a/templates/update-distribution.sh.erb
+++ b/templates/update-distribution.sh.erb
@@ -50,6 +50,7 @@ ls *.deb 2>/dev/null
 if [ $? -eq 0 ]; then 
   $REPREPRO -b ${BASEDIR}/${REPOSITORY} includedeb $DISTRIBUTION *.deb; 
   rm -f *.deb; 
+  $REPREPRO -b ${BASEDIR}/${REPOSITORY} export $DISTRIBUTION;
 
   if ${SNAPSHOTS}; then
     SNAPDIR="${BASEDIR}/${REPOSITORY}/dists/${DISTRIBUTION}/snapshots"


### PR DESCRIPTION
I put some new packages into the directory managed by reprepro::distribution::fIle["${basedir}/${repository}/tmp/${name}"].  They were included into a new "non-free" component directory.  I noticed after troubleshooting package visibility issues (they weren't available) that the Packages list for the non-free component was blank.  After running "reprepro export trusty", the non-free Packages list was updated.  I think this export should be done immediately after new package includes since it may be required and shouldn't be resource-intensive.  Thanks.