### PR TITLE
make 'origin', 'label', 'suite' and 'description' optional

### DIFF
--- a/manifests/distribution.pp
+++ b/manifests/distribution.pp
@@ -47,12 +47,12 @@
 #
 define reprepro::distribution (
   $repository,
-  $origin,
-  $label,
-  $suite,
   $architectures,
   $components,
-  $description,
+  $origin                 = undef,
+  $label                  = undef,
+  $suite                  = undef,
+  $description            = undef,
   $sign_with              = '',
   $codename               = $name,
   $ensure                 = present,
@@ -98,7 +98,7 @@ define reprepro::distribution (
   }
 
   # Configure system for automatically adding packages
-  file { "${basedir}/${repository}/tmp/${name}":
+  file { "${basedir}/${repository}/tmp/${codename}":
     ensure => directory,
     mode   => '0755',
     owner  => $::reprepro::params::user_name,
@@ -108,9 +108,9 @@ define reprepro::distribution (
   if $install_cron {
 
     if $snapshots {
-      $command = "${homedir}/bin/update-distribution.sh -r ${repository} -d ${suite} -c ${name} -s"
+      $command = "${homedir}/bin/update-distribution.sh -r ${repository} -c ${codename} -s"
     } else {
-      $command = "${homedir}/bin/update-distribution.sh -r ${repository} -d ${suite} -c ${name}"
+      $command = "${homedir}/bin/update-distribution.sh -r ${repository} -c ${codename}"
     }
 
     cron { "${name} cron":

--- a/templates/distribution.erb
+++ b/templates/distribution.erb
@@ -1,6 +1,12 @@
+<% if @origin -%>
 Origin: <%= @origin %>
+<% end -%>
+<% if @label -%>
 Label: <%= @label %>
+<% end -%>
+<% if @suite -%>
 Suite: <%= @suite %>
+<% end -%>
 Codename: <%= @codename %>
 Architectures: <%= @architectures %>
 Components: <%= @components %>
@@ -10,7 +16,9 @@ FakeComponentPrefix: <%= @fakecomponentprefix %>
 <% if @udebcomponents != "" -%>
 UDebComponents: <%= @udebcomponents %>
 <% end -%>
+<% if @description -%>
 Description: <%= @description %>
+<% end -%>
 DebIndices: <%= @deb_indices %>
 DscIndices: <%= @dsc_indices %>
 <% if @sign_with != "" -%>

--- a/templates/update-distribution.sh.erb
+++ b/templates/update-distribution.sh.erb
@@ -3,15 +3,12 @@ SNAPSHOTS=false
 BASEDIR="<%= @basedir %>"
 REPREPRO="/usr/bin/reprepro"
 
-usage () { echo "Usage: $0 -r <repository> -d <distribution> -c <codename> [-s]"; }
+usage () { echo "Usage: $0 -r <repository> -c <codename> [-s]"; }
 
 while getopts ":r:d:c:sh" opt; do
   case $opt in
     r)
       REPOSITORY=$OPTARG
-      ;;
-    d)
-      DISTRIBUTION=$OPTARG
       ;;
     c)
       CODENAME=$OPTARG
@@ -40,7 +37,7 @@ done
 
 shift $(($OPTIND - 1))
 
-if [ -z "$REPOSITORY" -o -z "$DISTRIBUTION" -o -z "$CODENAME" ]; then
+if [ -z "$REPOSITORY" -o -z "$CODENAME" ]; then
   usage
   exit 1
 fi
@@ -53,8 +50,8 @@ if [ $? -eq 0 ]; then
   $REPREPRO -b ${BASEDIR}/${REPOSITORY} export $CODENAME;
 
   if ${SNAPSHOTS}; then
-    SNAPDIR="${BASEDIR}/${REPOSITORY}/dists/${DISTRIBUTION}/snapshots"
+    SNAPDIR="${BASEDIR}/${REPOSITORY}/dists/${CODENAME}/snapshots"
     SNAPVER=$(if ls -d ${SNAPDIR}/[0-9]* &> /dev/null; then ls -d ${SNAPDIR}/[0-9]* | xargs -n 1 basename | sort -n | tail -1 | awk '{printf "%d", $1 + 1; exit}';else echo -n 0; fi)
-    $REPREPRO -b ${BASEDIR}/${REPOSITORY} gensnapshot $DISTRIBUTION $SNAPVER
+    $REPREPRO -b ${BASEDIR}/${REPOSITORY} gensnapshot $CODENAME $SNAPVER
   fi
 fi


### PR DESCRIPTION
Hi,

just another pull request I'd appreciate your validation for. According to reprepro manpage all these parameters are optional. Works for us like this, but I'm afraid someone wrote this on purpose.

Thanks in advance,
Mathias