### PR TITLE
reprepro::distribution: fix missing comma in parameters.

### DIFF
--- a/manifests/distribution.pp
+++ b/manifests/distribution.pp
@@ -68,7 +68,7 @@ define reprepro::distribution (
   $snapshots              = false,
   $install_cron           = true,
   $not_automatic          = '',
-  $but_automatic_upgrades = 'no'
+  $but_automatic_upgrades = 'no',
   $log                    = '',
 ) {
 


### PR DESCRIPTION
Hi,
Small commit to fix the parsing error before the $log class parameter (missing comma).