### PR TITLE
reprepro::key resource type to import PGP keys

### DIFF
--- a/manifests/key.pp
+++ b/manifests/key.pp
@@ -11,7 +11,7 @@
 #
 define reprepro::key (
   $key_source,
-  $homedir    = $::reprepro::params::homedir,
+  $homedir    = $::reprepro::homedir,
 ) {
 
   include reprepro::params
@@ -19,16 +19,16 @@ define reprepro::key (
   $keypath = "${homedir}/.gnupg/${name}"
   file {$keypath:
     ensure  => 'present',
-    owner   => $::reprepro::params::user_name,
-    group   => $::reprepro::params::group_name,
+    owner   => $::reprepro::user_name,
+    group   => $::reprepro::group_name,
     mode    => '0660',
     source  => $key_source,
-    require => User[$::reprepro::params::user_name],
+    require => User[$::reprepro::user_name],
     notify  => Exec["import-${name}"],
   }
 
   exec {"import-${name}":
-    command     => "su -c 'gpg --import ${keypath}' ${::reprepro::params::user_name}",
+    command     => "su -c 'gpg --import ${keypath}' ${::reprepro::user_name}",
     refreshonly => true,
   }
 }

--- a/manifests/key.pp
+++ b/manifests/key.pp
@@ -1,0 +1,35 @@
+# == Definition: reprepro::key
+#
+# Import a PGP key into the local keyring of the reprepro user
+#
+# === Parameters
+#
+# - *key_source* Path to the key in gpg --export format. This is
+#    used as the source parameter in a puppet File resource.
+# - *homedir* Home directory of the reprepro user. Defaults to
+#    /var/packages.
+#
+define reprepro::key (
+  $key_source,
+  $homedir    = $::reprepro::params::homedir,
+) {
+
+  include reprepro::params
+
+  $keypath = "${homedir}/.gnupg/${name}"
+  file {$keypath:
+    ensure  => 'present',
+    owner   => $::reprepro::params::user_name,
+    group   => $::reprepro::params::group_name,
+    mode    => '0660',
+    source  => $key_source,
+    require => User[$::reprepro::params::user_name],
+    notify  => Exec["import-${name}"],
+  }
+
+  exec {"import-${name}":
+    command     => "su -c 'gpg --import ${keypath}' ${::reprepro::params::user_name}",
+    refreshonly => true,
+  }
+}
+    


### PR DESCRIPTION
This (optional) resource type can be used to import PGP keys into the
local keyring of the reprepro user. It is usefull to import archive keys
for archives which are automatically updated.