### PR TITLE
remove inclusion of concat::setup

### DIFF
--- a/manifests/distribution.pp
+++ b/manifests/distribution.pp
@@ -72,9 +72,6 @@ define reprepro::distribution (
   $log                    = '',
 ) {
 
-  include reprepro::params
-  include concat::setup
-
   $notify = $ensure ? {
     'present' => Exec["export distribution ${name}"],
     default => undef,

--- a/manifests/repository.pp
+++ b/manifests/repository.pp
@@ -41,9 +41,6 @@ define reprepro::repository (
   $createsymlinks  = false,
   ) {
 
-  include reprepro::params
-  include concat::setup
-
   file { "${basedir}/${name}":
     ensure  => $ensure ? { 'present' => 'directory', default => $ensure,},
     purge   => $ensure ? { 'present' => undef,     default => true,},

--- a/manifests/update.pp
+++ b/manifests/update.pp
@@ -51,9 +51,6 @@ define reprepro::update (
   $getinrelease=undef,
 ) {
 
-  include reprepro::params
-  include concat::setup
-
   if $flat and ($components or $udebcomponents) {
     fail('$components and $udebcomponents are not allowed when $flat is provided.')
   }

--- a/spec/defines/distribution_spec.rb
+++ b/spec/defines/distribution_spec.rb
@@ -27,9 +27,6 @@ describe 'reprepro::distribution' do
       })
     end
 
-    it { should contain_class('reprepro::params') }
-    it { should contain_class('concat::setup') }
-
     it do
       should contain_concat__fragment('distribution-precise').with({
         :target => '/var/packages/localpkgs/conf/distributions'

--- a/spec/defines/update_spec.rb
+++ b/spec/defines/update_spec.rb
@@ -24,9 +24,6 @@ describe 'reprepro::update' do
     concatdir        = '/var/lib/puppet/concat'
     fragdir          = "#{concatdir}/#{safe_target_name}"
 
-    it { should contain_class('reprepro::params') }
-    it { should contain_class('concat::setup') }
-
     it do
       should contain_concat__fragment(fragment).with({
         :target => target


### PR DESCRIPTION
the usage of concat::setup will be removed
in version 2.0 of cpncat. For versions => 1.1 a
deprecation warning appears, and the inclusion is not necessary
anymore.